### PR TITLE
Force MinGW 11.2

### DIFF
--- a/.github/workflows/build/windows/action.yml
+++ b/.github/workflows/build/windows/action.yml
@@ -9,6 +9,10 @@ runs:
   using: "composite"
   steps:
 
+  - name: Install MinGW
+    shell: bash
+    run: choco install -y mingw --version=11.2.0 --allow-downgrade
+
   - name: Collect zstd
     shell: bash
     run: |


### PR DESCRIPTION
Quick PR to pin our MinGW version on Windows to 11.2 - sometimes a newer 12.X version is picked up, and this has link-time errors with our pre-built HDF5 libraries (built with MinGW 8.1, but that's a whole other story...).